### PR TITLE
Fix bug where mob follow range overrides are not synchronised with targeting goals

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -9,7 +9,7 @@ yarn_mappings=1.17.1+build.54
 loader_version=0.11.6
 
 # Mod Properties
-mod_version=1.0a-1.17
+mod_version=1.1-1.17
 maven_group=sindarin
 archives_base_name=farsighted-mobs
 

--- a/src/main/java/sindarin/farsightedmobs/FarsightedMobs.java
+++ b/src/main/java/sindarin/farsightedmobs/FarsightedMobs.java
@@ -6,13 +6,14 @@ import net.fabricmc.api.ModInitializer;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.EntityType;
 import net.minecraft.entity.LivingEntity;
+import net.minecraft.entity.ai.goal.FollowTargetGoal;
+import net.minecraft.entity.ai.goal.Goal;
 import net.minecraft.entity.attribute.EntityAttributes;
+import net.minecraft.entity.mob.MobEntity;
 import net.minecraft.util.Identifier;
-import org.apache.logging.log4j.Level;
-import org.apache.logging.log4j.Logger;
 import sindarin.farsightedmobs.config.ModConfig;
-
-import java.util.HashMap;
+import sindarin.farsightedmobs.mixin.FollowTargetGoalAccessor;
+import sindarin.farsightedmobs.mixin.MobEntityAccessor;
 
 public class FarsightedMobs implements ModInitializer {
     public static ModConfig CONFIG = new ModConfig();
@@ -29,9 +30,23 @@ public class FarsightedMobs implements ModInitializer {
             if (FarsightedMobs.CONFIG.followRanges.containsKey(type.toString())) {
                 int range = FarsightedMobs.CONFIG.followRanges.get(type.toString());
                 living.getAttributeInstance(EntityAttributes.GENERIC_FOLLOW_RANGE).setBaseValue(range);
+                FixFollowRange(living);
                 return living;
             }
         }
         return e;
+    }
+
+    public static void FixFollowRange(LivingEntity livingEntity) {
+        if (livingEntity instanceof MobEntity) {
+            ((MobEntityAccessor) livingEntity).getTargetSelector().getGoals().forEach(prioritizedGoal -> {
+                Goal goal = prioritizedGoal.getGoal();
+                if (goal instanceof FollowTargetGoal) {
+                    FollowTargetGoalAccessor followTargetGoal = (FollowTargetGoalAccessor)  goal;
+                    followTargetGoal.setTargetPredicate(followTargetGoal.getTargetPredicate()
+                            .setBaseMaxDistance(livingEntity.getAttributeValue(EntityAttributes.GENERIC_FOLLOW_RANGE)));
+                }
+            });
+        }
     }
 }

--- a/src/main/java/sindarin/farsightedmobs/mixin/FollowTargetGoalAccessor.java
+++ b/src/main/java/sindarin/farsightedmobs/mixin/FollowTargetGoalAccessor.java
@@ -1,0 +1,15 @@
+package sindarin.farsightedmobs.mixin;
+
+import net.minecraft.entity.ai.TargetPredicate;
+import net.minecraft.entity.ai.goal.FollowTargetGoal;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.gen.Accessor;
+
+@Mixin(FollowTargetGoal.class)
+public interface FollowTargetGoalAccessor {
+    @Accessor
+    TargetPredicate getTargetPredicate();
+
+    @Accessor("targetPredicate")
+    void setTargetPredicate(TargetPredicate targetPredicate);
+}

--- a/src/main/java/sindarin/farsightedmobs/mixin/HostileEntityMixin.java
+++ b/src/main/java/sindarin/farsightedmobs/mixin/HostileEntityMixin.java
@@ -1,19 +1,23 @@
 package sindarin.farsightedmobs.mixin;
 
+import net.minecraft.entity.ai.goal.GoalSelector;
 import net.minecraft.entity.attribute.DefaultAttributeContainer;
 import net.minecraft.entity.attribute.EntityAttributes;
 import net.minecraft.entity.mob.HostileEntity;
 import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.gen.Accessor;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 import sindarin.farsightedmobs.FarsightedMobs;
 
 @Mixin(value= HostileEntity.class)
-public class MobEntityMixin {
+public class HostileEntityMixin {
     @Inject(method="createHostileAttributes", at=@At(value="RETURN"))
     private static void createAttributes(CallbackInfoReturnable<DefaultAttributeContainer.Builder> ci) {
         int range = FarsightedMobs.CONFIG.hostileDefaultRange;
         ci.getReturnValue().add(EntityAttributes.GENERIC_FOLLOW_RANGE, range);
     }
+
+
 }

--- a/src/main/java/sindarin/farsightedmobs/mixin/MobEntityAccessor.java
+++ b/src/main/java/sindarin/farsightedmobs/mixin/MobEntityAccessor.java
@@ -1,0 +1,12 @@
+package sindarin.farsightedmobs.mixin;
+
+import net.minecraft.entity.ai.goal.GoalSelector;
+import net.minecraft.entity.mob.MobEntity;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.gen.Accessor;
+
+@Mixin(MobEntity.class)
+public interface MobEntityAccessor {
+    @Accessor
+    GoalSelector getTargetSelector();
+}

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -25,6 +25,7 @@
     "fabricloader": ">=0.11.3",
     "fabric": "*",
     "minecraft": "1.17.x",
-    "java": ">=16"
+    "java": ">=16",
+    "cloth-config2": ">=5.0.38"
   }
 }

--- a/src/main/resources/farsighted-mobs.mixins.json
+++ b/src/main/resources/farsighted-mobs.mixins.json
@@ -5,7 +5,9 @@
   "compatibilityLevel": "JAVA_8",
   "mixins": [
     "EntityTypeMixin",
-    "MobEntityMixin"
+    "FollowTargetGoalAccessor",
+    "HostileEntityMixin",
+    "MobEntityAccessor"
   ],
   "client": [
   ],


### PR DESCRIPTION
- Add accessors for mob target selector
- Add accessors for FollowTargetGoal's target predicate
- Rename MobEntityMixin to HostileEntityMixin to better reflect the mappings
- Add a method to fix a mob's follow range in instances of FollowTargetGoal
- Call the above method whenever a mob's follow range is overridden by the mod
- Change version number to 1.1-1.17

closes #1