### PR TITLE
Fix MC-145656 for mobs changed by this mod

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -6,7 +6,7 @@ minecraft_version=1.16.3
 yarn_mappings=1.16.3+build.17
 loader_version=0.10.0+build.208
 # Mod Properties
-mod_version=1.0a
+mod_version=1.1-1.16
 maven_group=sindarin
 archives_base_name=farsighted-mobs
 # Dependencies

--- a/src/main/java/sindarin/farsightedmobs/FarsightedMobs.java
+++ b/src/main/java/sindarin/farsightedmobs/FarsightedMobs.java
@@ -6,11 +6,17 @@ import net.fabricmc.api.ModInitializer;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.EntityType;
 import net.minecraft.entity.LivingEntity;
+import net.minecraft.entity.ai.goal.FollowTargetGoal;
+import net.minecraft.entity.ai.goal.Goal;
 import net.minecraft.entity.attribute.EntityAttributes;
+import net.minecraft.entity.mob.MobEntity;
 import net.minecraft.util.Identifier;
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.Logger;
 import sindarin.farsightedmobs.config.ModConfig;
+import sindarin.farsightedmobs.mixin.FollowTargetGoalAccessor;
+import sindarin.farsightedmobs.mixin.GoalSelectorAccessor;
+import sindarin.farsightedmobs.mixin.MobEntityAccessor;
 
 import java.util.HashMap;
 
@@ -29,9 +35,23 @@ public class FarsightedMobs implements ModInitializer {
             if (FarsightedMobs.CONFIG.followRanges.containsKey(type.toString())) {
                 int range = FarsightedMobs.CONFIG.followRanges.get(type.toString());
                 living.getAttributeInstance(EntityAttributes.GENERIC_FOLLOW_RANGE).setBaseValue(range);
+                FixFollowRange(living);
                 return living;
             }
         }
         return e;
+    }
+
+    public static void FixFollowRange(LivingEntity livingEntity) {
+        if (livingEntity instanceof MobEntity) {
+            ((GoalSelectorAccessor)((MobEntityAccessor) livingEntity).getTargetSelector()).getGoals().forEach(prioritizedGoal -> {
+                Goal goal = prioritizedGoal.getGoal();
+                if (goal instanceof FollowTargetGoal) {
+                    FollowTargetGoalAccessor followTargetGoal = (FollowTargetGoalAccessor)  goal;
+                    followTargetGoal.setTargetPredicate(followTargetGoal.getTargetPredicate()
+                            .setBaseMaxDistance(livingEntity.getAttributeValue(EntityAttributes.GENERIC_FOLLOW_RANGE)));
+                }
+            });
+        }
     }
 }

--- a/src/main/java/sindarin/farsightedmobs/mixin/FollowTargetGoalAccessor.java
+++ b/src/main/java/sindarin/farsightedmobs/mixin/FollowTargetGoalAccessor.java
@@ -1,0 +1,15 @@
+package sindarin.farsightedmobs.mixin;
+
+import net.minecraft.entity.ai.TargetPredicate;
+import net.minecraft.entity.ai.goal.FollowTargetGoal;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.gen.Accessor;
+
+@Mixin(FollowTargetGoal.class)
+public interface FollowTargetGoalAccessor {
+    @Accessor
+    TargetPredicate getTargetPredicate();
+
+    @Accessor("targetPredicate")
+    void setTargetPredicate(TargetPredicate targetPredicate);
+}

--- a/src/main/java/sindarin/farsightedmobs/mixin/GoalSelectorAccessor.java
+++ b/src/main/java/sindarin/farsightedmobs/mixin/GoalSelectorAccessor.java
@@ -1,0 +1,14 @@
+package sindarin.farsightedmobs.mixin;
+
+import net.minecraft.entity.ai.goal.GoalSelector;
+import net.minecraft.entity.ai.goal.PrioritizedGoal;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.gen.Accessor;
+
+import java.util.Set;
+
+@Mixin(GoalSelector.class)
+public interface GoalSelectorAccessor {
+    @Accessor
+    Set<PrioritizedGoal> getGoals();
+}

--- a/src/main/java/sindarin/farsightedmobs/mixin/HostileEntityMixin.java
+++ b/src/main/java/sindarin/farsightedmobs/mixin/HostileEntityMixin.java
@@ -11,7 +11,7 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 import sindarin.farsightedmobs.FarsightedMobs;
 
 @Mixin(value= HostileEntity.class)
-public class MobEntityMixin {
+public class HostileEntityMixin {
     @Inject(method="createHostileAttributes", at=@At(value="RETURN"))
     private static void createAttributes(CallbackInfoReturnable<DefaultAttributeContainer.Builder> ci) {
         int range = FarsightedMobs.CONFIG.hostileDefaultRange;

--- a/src/main/java/sindarin/farsightedmobs/mixin/MobEntityAccessor.java
+++ b/src/main/java/sindarin/farsightedmobs/mixin/MobEntityAccessor.java
@@ -1,0 +1,12 @@
+package sindarin.farsightedmobs.mixin;
+
+import net.minecraft.entity.ai.goal.GoalSelector;
+import net.minecraft.entity.mob.MobEntity;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.gen.Accessor;
+
+@Mixin(MobEntity.class)
+public interface MobEntityAccessor {
+    @Accessor
+    GoalSelector getTargetSelector();
+}

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -20,6 +20,7 @@
   "depends": {
     "fabricloader": ">=0.10.0+build.208",
     "fabric": "*",
-    "minecraft": "1.16.x"
+    "minecraft": "1.16.x",
+    "autoconfig1u": ">=3.2.2"
   }
 }

--- a/src/main/resources/farsighted-mobs.mixins.json
+++ b/src/main/resources/farsighted-mobs.mixins.json
@@ -5,7 +5,10 @@
   "compatibilityLevel": "JAVA_8",
   "mixins": [
     "EntityTypeMixin",
-    "MobEntityMixin"
+    "FollowTargetGoalAccessor",
+    "GoalSelectorAccessor",
+    "HostileEntityMixin",
+    "MobEntityAccessor"
   ],
   "client": [
   ],


### PR DESCRIPTION
- Enforce dependency on autoconfig1u
- Add accessors for mob target selector
- Add accessors for FollowTargetGoal's target predicate
- Add accessors for GoalSelector's goals
- Rename MobEntityMixin to HostileEntityMixin to better reflect the mappings
- Add a method to fix a mob's follow range in instances of FollowTargetGoal
- Call the above method whenever a mob's follow range is overridden by the mod
- Change version number to 1.1-1.16

closes #1 